### PR TITLE
[AD-80] Fix password update failure during updateDelta

### DIFF
--- a/src/main/java/net/tirasa/connid/bundles/ad/ADConfiguration.java
+++ b/src/main/java/net/tirasa/connid/bundles/ad/ADConfiguration.java
@@ -361,4 +361,9 @@ public final class ADConfiguration extends LdapConfiguration {
             this.userAuthenticationAttributes = userAuthenticationAttributes.clone();
         }
     }
+
+    @Override
+    public String getPasswordHashAlgorithm() {
+        return "NONE";
+    }
 }

--- a/src/main/java/net/tirasa/connid/bundles/ad/ADConnector.java
+++ b/src/main/java/net/tirasa/connid/bundles/ad/ADConnector.java
@@ -31,6 +31,7 @@ import net.tirasa.connid.bundles.ldap.search.LdapFilter;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.objects.Attribute;
 import org.identityconnectors.framework.common.objects.AttributeBuilder;
+import org.identityconnectors.framework.common.objects.AttributeDelta;
 import org.identityconnectors.framework.common.objects.AttributeUtil;
 import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.common.objects.OperationOptions;
@@ -156,6 +157,14 @@ public class ADConnector extends LdapConnector {
         }
 
         return new ADUpdate((ADConnection) conn, oclass, uid).update(attributes);
+    }
+
+    @Override
+    public Set<AttributeDelta> updateDelta(final ObjectClass oclass,
+            final Uid uid,
+            final Set<AttributeDelta> modifications,
+            final OperationOptions options) {
+        return new ADUpdate((ADConnection) conn, oclass, uid).updateDelta(modifications);
     }
 
     @Override

--- a/src/main/java/net/tirasa/connid/bundles/ad/schema/ADSchema.java
+++ b/src/main/java/net/tirasa/connid/bundles/ad/schema/ADSchema.java
@@ -16,8 +16,12 @@
 package net.tirasa.connid.bundles.ad.schema;
 
 import net.tirasa.connid.bundles.ad.ADConnection;
+import net.tirasa.connid.bundles.ad.util.ADGuardedPasswordAttribute;
 import net.tirasa.connid.bundles.ldap.schema.LdapSchema;
+import org.identityconnectors.common.CollectionUtil;
 import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.common.security.GuardedString;
+import org.identityconnectors.framework.common.objects.AttributeDelta;
 import org.identityconnectors.framework.common.objects.AttributeUtil;
 import org.identityconnectors.framework.common.objects.Name;
 import org.identityconnectors.framework.common.objects.ObjectClass;
@@ -61,5 +65,15 @@ public class ADSchema extends LdapSchema {
                     attrName, oclass.getObjectClassValue());
         }
         return result;
+    }
+
+    @Override
+    public ADGuardedPasswordAttribute encodePassword(AttributeDelta attr) {
+        assert attr.is(OperationalAttributes.PASSWORD_NAME);
+
+        String pwdAttrName = this.conn.getConfiguration().getPasswordAttribute();
+        return CollectionUtil.isEmpty(attr.getValuesToReplace())
+                ? null
+                : ADGuardedPasswordAttribute.create(pwdAttrName, (GuardedString) attr.getValuesToReplace().get(0));
     }
 }

--- a/src/test/java/net/tirasa/connid/bundles/ad/crud/UserCrudTestITCase.java
+++ b/src/test/java/net/tirasa/connid/bundles/ad/crud/UserCrudTestITCase.java
@@ -503,7 +503,6 @@ public class UserCrudTestITCase extends UserTest {
     }
 
     @Test
-    @Disabled("Update Delta with value already present not possible with Samba")
     public void updateDelta() {
         // 1. take user and set attribute
         final Map.Entry<String, String> ids = util.getEntryIDs("3");
@@ -542,11 +541,8 @@ public class UserCrudTestITCase extends UserTest {
         assertTrue(numberAttr.contains(NUMBER2));
 
         // 4. updateDelta with values to replace
-        assertDoesNotThrow(() -> connector.authenticate(
-                ObjectClass.ACCOUNT, ids.getValue(), new GuardedString("carrot".toCharArray()), null));
-
         delta = AttributeDeltaBuilder.build("telephoneNumber", CollectionUtil.newList(NUMBER1, NUMBER3));
-        GuardedString newPwd = new GuardedString("newPwd".toCharArray());
+        GuardedString newPwd = new GuardedString("NuovaPassword123!".toCharArray());
         connector.updateDelta(
                 ObjectClass.ACCOUNT,
                 new Uid(ids.getValue()),

--- a/src/test/resources/docker/tirasaad/samba-ad-setup.sh
+++ b/src/test/resources/docker/tirasaad/samba-ad-setup.sh
@@ -39,6 +39,9 @@ samba-tool domain provision\
  --domain=IAM\
  --adminpass=${SMB_ADMIN_PASSWORD}
 
+#Modifica schema per cambio attributo single-value
+ldbmodify -H /var/lib/samba/private/sam.ldb.d/CN=SCHEMA,CN=CONFIGURATION,DC=LOCALHOST.ldb single-value.ldif
+
 samba-tool ou create "OU=ARTE,DC=localhost"
 samba-tool ou create "OU=1-DGDSIS-Digitalizzazione Sistemi Informativi Statistici,OU=ARTE,DC=localhost"
 samba-tool ou create "OU=Utenti,OU=1-DGDSIS-Digitalizzazione Sistemi Informativi Statistici,OU=ARTE,DC=localhost"

--- a/src/test/resources/docker/tirasaad/single-value.ldif
+++ b/src/test/resources/docker/tirasaad/single-value.ldif
@@ -1,0 +1,4 @@
+dn: CN=Telephone-Number,CN=Schema,CN=Configuration,DC=localhost
+changetype: modify
+replace: isSingleValued
+isSingleValued: FALSE


### PR DESCRIPTION
Encode passwords with UTF-16LE and disable hashing in updateDelta. 
Re-enabled updateDelta tests by manually configuring the telephoneNumber schema as multi-valued to bypass Samba limitations.